### PR TITLE
feat: add django-admin skill

### DIFF
--- a/skills/django-admin/SKILL.md
+++ b/skills/django-admin/SKILL.md
@@ -23,12 +23,20 @@ class OrderAdmin(admin.ModelAdmin):
     ordering = ["-created_at"]
     date_hierarchy = "created_at"
 
+    @admin.display(description="Customer", ordering="customer__name")
     def customer_link(self, obj):
         url = reverse("admin:accounts_customer_change", args=[obj.customer_id])
         return format_html('<a href="{}">{}</a>', url, obj.customer)
-    customer_link.short_description = "Customer"
-    customer_link.admin_order_field = "customer__name"
 ```
+
+**`list_display` with `__` lookups (Django 5.1+):** You can now use `__` traversal directly in `list_display` to display related fields without writing a callable:
+
+```python
+class OrderAdmin(admin.ModelAdmin):
+    list_display = ["id", "customer__email", "customer__name", "status"]
+```
+
+Django automatically generates a column header from the field path. For custom headers or ordering, use a callable with `@admin.display()`.
 
 **list_filter tips:**
 - Use `admin.RelatedOnlyFieldListFilter` to filter FK dropdowns to values that actually appear in the list — prevents overly long filter sidebars on large datasets.
@@ -63,9 +71,9 @@ class OrderAdmin(admin.ModelAdmin):
             return self.readonly_fields + ["customer", "merchant"]
         return self.readonly_fields
 
+    @admin.display(description="Total")
     def total_display(self, obj):
         return f"{obj.total} {obj.currency}"
-    total_display.short_description = "Total"
 ```
 
 `get_readonly_fields(request, obj=None)` is the right hook — `obj` is `None` for add forms, an instance for change forms. Use this for state-dependent locking.
@@ -81,9 +89,9 @@ class OrderItemInline(admin.TabularInline):
     fields = ["product", "quantity", "unit_price", "line_total"]
     readonly_fields = ["line_total"]
 
+    @admin.display(description="Total")
     def line_total(self, obj):
         return obj.quantity * obj.unit_price
-    line_total.short_description = "Total"
 
 
 class OrderNoteInline(admin.StackedInline):
@@ -287,18 +295,17 @@ class OrderAdmin(admin.ModelAdmin):
         qs = qs.annotate(item_count_annotation=Count("items"))
         return qs
 
+    @admin.display(ordering="customer__email")
     def customer_email(self, obj):
         return obj.customer.email  # No extra query: list_select_related
-    customer_email.admin_order_field = "customer__email"
 
+    @admin.display(ordering="merchant__name")
     def merchant_name(self, obj):
         return obj.merchant.name  # No extra query: list_select_related
-    merchant_name.admin_order_field = "merchant__name"
 
+    @admin.display(description="Items", ordering="item_count_annotation")
     def item_count(self, obj):
         return obj.item_count_annotation
-    item_count.short_description = "Items"
-    item_count.admin_order_field = "item_count_annotation"
 ```
 
 **`list_select_related`** — set to a list of FK field names for the list view only. Setting it to `True` does an unbounded `select_related()` — avoid that.
@@ -376,6 +383,8 @@ Register models to each site explicitly. Models on the default `django.contrib.a
 
 - `extra = 0` on all inlines in production
 - `list_select_related` with explicit field list, never `True`
+- Use `__` lookups in `list_display` for simple related field display (Django 5.1+); use `@admin.display()` when you need a custom label, ordering, or logic
+- Use `@admin.display(description=..., ordering=...)` on callables — not the old `func.short_description` / `func.admin_order_field` attribute pattern
 - Override `get_queryset()` to add annotations and prefetches that match `list_display`
 - `show_full_result_count = False` for large tables
 - Use `self.admin_site.admin_view()` to wrap custom view functions

--- a/skills/django-admin/SKILL.md
+++ b/skills/django-admin/SKILL.md
@@ -1,0 +1,386 @@
+---
+name: django-admin
+description: Django admin patterns for ModelAdmin, inlines, custom actions, custom views, permissions, and performance. Use when writing or customizing Django admin classes.
+user-invocable: false
+---
+
+# Django Admin Patterns
+
+Practical patterns for building maintainable, performant Django admin interfaces.
+
+## ModelAdmin: list_display, list_filter, search, ordering
+
+```python
+from django.contrib import admin
+from django.utils.html import format_html
+from .models import Order
+
+@admin.register(Order)
+class OrderAdmin(admin.ModelAdmin):
+    list_display = ["id", "customer_link", "status", "total", "created_at"]
+    list_filter = ["status", "created_at", ("merchant", admin.RelatedOnlyFieldListFilter)]
+    search_fields = ["id", "customer__email", "customer__name"]
+    ordering = ["-created_at"]
+    date_hierarchy = "created_at"
+
+    def customer_link(self, obj):
+        url = reverse("admin:accounts_customer_change", args=[obj.customer_id])
+        return format_html('<a href="{}">{}</a>', url, obj.customer)
+    customer_link.short_description = "Customer"
+    customer_link.admin_order_field = "customer__name"
+```
+
+**list_filter tips:**
+- Use `admin.RelatedOnlyFieldListFilter` to filter FK dropdowns to values that actually appear in the list — prevents overly long filter sidebars on large datasets.
+- Use `SimpleListFilter` for computed or multi-field filters.
+
+```python
+class ActiveMerchantFilter(admin.SimpleListFilter):
+    title = "merchant status"
+    parameter_name = "merchant_active"
+
+    def lookups(self, request, model_admin):
+        return [("yes", "Active"), ("no", "Inactive")]
+
+    def queryset(self, request, queryset):
+        if self.value() == "yes":
+            return queryset.filter(merchant__is_active=True)
+        if self.value() == "no":
+            return queryset.filter(merchant__is_active=False)
+        return queryset
+```
+
+## Readonly Fields and Conditional Display
+
+```python
+@admin.register(Order)
+class OrderAdmin(admin.ModelAdmin):
+    readonly_fields = ["created_at", "updated_at", "total_display"]
+
+    def get_readonly_fields(self, request, obj=None):
+        # Lock fields after submission
+        if obj and obj.status != Order.Status.DRAFT:
+            return self.readonly_fields + ["customer", "merchant"]
+        return self.readonly_fields
+
+    def total_display(self, obj):
+        return f"{obj.total} {obj.currency}"
+    total_display.short_description = "Total"
+```
+
+`get_readonly_fields(request, obj=None)` is the right hook — `obj` is `None` for add forms, an instance for change forms. Use this for state-dependent locking.
+
+## Inlines: Tabular vs Stacked, Limits
+
+```python
+class OrderItemInline(admin.TabularInline):
+    model = OrderItem
+    extra = 0          # Don't show blank rows by default
+    max_num = 50       # Cap total allowed rows
+    show_change_link = True
+    fields = ["product", "quantity", "unit_price", "line_total"]
+    readonly_fields = ["line_total"]
+
+    def line_total(self, obj):
+        return obj.quantity * obj.unit_price
+    line_total.short_description = "Total"
+
+
+class OrderNoteInline(admin.StackedInline):
+    model = OrderNote
+    extra = 1
+    fields = ["text", "created_by"]
+    readonly_fields = ["created_by"]
+
+    def save_model(self, request, obj, form, change):
+        if not obj.pk:
+            obj.created_by = request.user
+        super().save_model(request, obj, form, change)
+
+
+@admin.register(Order)
+class OrderAdmin(admin.ModelAdmin):
+    inlines = [OrderItemInline, OrderNoteInline]
+```
+
+**Tabular** — compact, good for many rows with few fields.
+**Stacked** — verbose, good for few rows with many fields.
+
+Always set `extra = 0` in production — blank rows confuse users and generate empty validation errors on save.
+
+For nested inlines (inline inside inline), Django doesn't support this natively. Use `django-nested-admin` if needed, but prefer flatter models.
+
+## Custom Actions (Bulk and Single-Object)
+
+```python
+from django.contrib import messages
+from django.utils.translation import ngettext
+
+
+@admin.action(description="Mark selected orders as shipped")
+def mark_shipped(modeladmin, request, queryset):
+    updated = queryset.filter(status=Order.Status.PAID).update(
+        status=Order.Status.SHIPPED
+    )
+    modeladmin.message_user(
+        request,
+        ngettext(
+            "%d order marked as shipped.",
+            "%d orders marked as shipped.",
+            updated,
+        ) % updated,
+        messages.SUCCESS,
+    )
+
+
+@admin.register(Order)
+class OrderAdmin(admin.ModelAdmin):
+    actions = [mark_shipped]
+```
+
+**Single-object action** via a custom change-form button is better done as a custom view (see below) or a dedicated URL in `change_view`. For simple single-object transitions, add a method that renders a button via `readonly_fields` and handle the POST in a custom URL.
+
+**Guarding actions:**
+```python
+@admin.action(description="Refund selected orders")
+def refund_orders(modeladmin, request, queryset):
+    if not request.user.has_perm("orders.can_refund"):
+        modeladmin.message_user(request, "Permission denied.", messages.ERROR)
+        return
+    for order in queryset:
+        OrderService.refund(order=order, user=request.user)
+```
+
+## Custom Admin Views and URLs
+
+Add custom views to a `ModelAdmin` by overriding `get_urls()`:
+
+```python
+from django.urls import path
+from django.shortcuts import get_object_or_404, redirect
+from django.contrib.admin.views.decorators import staff_member_required
+from django.utils.decorators import method_decorator
+
+
+@admin.register(Order)
+class OrderAdmin(admin.ModelAdmin):
+    change_form_template = "admin/orders/order/change_form.html"
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom_urls = [
+            path(
+                "<int:pk>/refund/",
+                self.admin_site.admin_view(self.refund_view),
+                name="orders_order_refund",
+            ),
+        ]
+        return custom_urls + urls
+
+    def refund_view(self, request, pk):
+        order = get_object_or_404(Order, pk=pk)
+        if request.method == "POST":
+            OrderService.refund(order=order, user=request.user)
+            self.message_user(request, "Order refunded.", messages.SUCCESS)
+            return redirect(
+                reverse("admin:orders_order_change", args=[pk])
+            )
+        # GET: render a confirmation page
+        context = {
+            **self.admin_site.each_context(request),
+            "order": order,
+            "opts": self.model._meta,
+            "title": f"Refund order {order.id}",
+        }
+        return render(request, "admin/orders/order/refund_confirm.html", context)
+```
+
+Always use `self.admin_site.admin_view(...)` — it enforces login and `is_staff` checks. Add the button to the template:
+
+```html
+{# templates/admin/orders/order/change_form.html #}
+{% extends "admin/change_form.html" %}
+{% block object-tools-items %}
+    {{ block.super }}
+    {% if original %}
+    <li>
+        <a href="{% url 'admin:orders_order_refund' original.pk %}" class="button">
+            Refund
+        </a>
+    </li>
+    {% endif %}
+{% endblock %}
+```
+
+## Admin Template Overriding
+
+Django resolves admin templates in this order:
+1. `templates/admin/<app_label>/<model_name>/<template>.html`
+2. `templates/admin/<app_label>/<template>.html`
+3. `templates/admin/<template>.html`
+4. Django's built-in admin templates
+
+Override the minimum needed — extend the parent template and fill specific blocks:
+
+```html
+{# templates/admin/orders/order/change_list.html #}
+{% extends "admin/change_list.html" %}
+
+{% block content_title %}
+    <h1>Orders — {{ cl.result_count }} result{{ cl.result_count|pluralize }}</h1>
+{% endblock %}
+
+{% block object-tools-items %}
+    {{ block.super }}
+    <li><a href="{% url 'admin:orders_order_export' %}" class="button">Export CSV</a></li>
+{% endblock %}
+```
+
+Useful blocks: `content_title`, `object-tools-items`, `submit_row`, `field_sets`, `after_related_objects`.
+
+For global admin changes (header, branding), override `templates/admin/base_site.html`:
+
+```html
+{% extends "admin/base.html" %}
+{% block branding %}<h1 id="site-name">My App Admin</h1>{% endblock %}
+```
+
+## Admin Permissions Patterns
+
+```python
+@admin.register(Order)
+class OrderAdmin(admin.ModelAdmin):
+    def has_add_permission(self, request):
+        return request.user.is_superuser
+
+    def has_change_permission(self, request, obj=None):
+        if obj is None:
+            return True  # Allow list view
+        return request.user.is_superuser or obj.merchant == request.user.merchant
+
+    def has_delete_permission(self, request, obj=None):
+        return False  # Never delete orders through admin
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        if request.user.is_superuser:
+            return qs
+        # Scope to the user's own merchant
+        return qs.filter(merchant=request.user.merchant)
+```
+
+Override `get_queryset()` in combination with `has_*_permission()` to scope both the list and form views. `get_queryset()` alone is sufficient to prevent list access, but permission methods are needed to block direct URL access.
+
+## Performance: get_queryset, select_related, prefetch
+
+The admin calls `get_queryset()` for every list view. Override it to add prefetches that match `list_display`:
+
+```python
+@admin.register(Order)
+class OrderAdmin(admin.ModelAdmin):
+    list_display = ["id", "customer_email", "merchant_name", "item_count", "status"]
+    list_select_related = ["customer", "merchant"]  # Simple FK joins on list view
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        qs = qs.prefetch_related("items")
+        qs = qs.annotate(item_count_annotation=Count("items"))
+        return qs
+
+    def customer_email(self, obj):
+        return obj.customer.email  # No extra query: list_select_related
+    customer_email.admin_order_field = "customer__email"
+
+    def merchant_name(self, obj):
+        return obj.merchant.name  # No extra query: list_select_related
+    merchant_name.admin_order_field = "merchant__name"
+
+    def item_count(self, obj):
+        return obj.item_count_annotation
+    item_count.short_description = "Items"
+    item_count.admin_order_field = "item_count_annotation"
+```
+
+**`list_select_related`** — set to a list of FK field names for the list view only. Setting it to `True` does an unbounded `select_related()` — avoid that.
+
+**`show_full_result_count = False`** — disable the expensive `COUNT(*)` on the full unfiltered table when the list is filtered. Default is `True`.
+
+```python
+class OrderAdmin(admin.ModelAdmin):
+    show_full_result_count = False
+```
+
+## Admin Site Customization
+
+### Subclass AdminSite for branding/title
+
+```python
+# admin_site.py
+from django.contrib.admin import AdminSite
+
+class MyAdminSite(AdminSite):
+    site_header = "My App Administration"
+    site_title = "My App"
+    index_title = "Dashboard"
+
+
+admin_site = MyAdminSite(name="myadmin")
+```
+
+```python
+# apps.py
+from django.apps import AppConfig
+
+class CoreConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "core"
+
+    def ready(self):
+        from .admin_site import admin_site
+        # Re-register everything or use the custom site directly in each app
+```
+
+Use `@admin_site.register(Model)` or `admin_site.register(Model, ModelAdmin)` instead of `admin.register`.
+
+### Multiple Admin Sites
+
+Two independent admin sites — e.g., one for staff and one for a client-facing support portal:
+
+```python
+# admin_site.py
+from django.contrib.admin import AdminSite
+
+class StaffAdminSite(AdminSite):
+    site_header = "Staff Portal"
+
+class SupportAdminSite(AdminSite):
+    site_header = "Support Portal"
+
+staff_admin = StaffAdminSite(name="staff_admin")
+support_admin = SupportAdminSite(name="support_admin")
+```
+
+```python
+# urls.py
+from .admin_site import staff_admin, support_admin
+
+urlpatterns = [
+    path("staff/", staff_admin.urls),
+    path("support/", support_admin.urls),
+]
+```
+
+Register models to each site explicitly. Models on the default `django.contrib.admin.site` are invisible to custom sites.
+
+## Summary
+
+- `extra = 0` on all inlines in production
+- `list_select_related` with explicit field list, never `True`
+- Override `get_queryset()` to add annotations and prefetches that match `list_display`
+- `show_full_result_count = False` for large tables
+- Use `self.admin_site.admin_view()` to wrap custom view functions
+- Scope access in both `get_queryset()` and `has_*_permission()` — one without the other is incomplete
+- `get_readonly_fields(request, obj=None)` for state-dependent locking; `obj` is `None` on add
+- Override admin templates at the narrowest scope (`app/model/template.html` before `app/template.html`)
+
+---

--- a/skills/django-signals/SKILL.md
+++ b/skills/django-signals/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: django-signals
+description: Django signal patterns for decoupled side effects. Use when wiring up cross-app reactions, custom signal definitions, or async dispatch (Django 5.0+).
+user-invocable: false
+---
+
+# Django Signals
+
+Signals are for **decoupled, cross-app side effects** — when the sender shouldn't know about the receiver. They're not a general-purpose hook mechanism. If the logic belongs to the same app or model, prefer save hooks or services.
+
+## Signals vs. Save Hooks vs. Services
+
+| Scenario | Pattern |
+|---|---|
+| Post-save logic that needs dirty-field tracking or bulk support | Save hook (see `django-save-hooks` skill) |
+| Business logic coordinating multiple models or external systems | Service (see `django-services` skill) |
+| Cross-app reaction where the sender should not import the receiver | Signal |
+| Plugin-style extensibility (third-party apps hooking in) | Signal |
+
+Signals add indirection that makes code harder to trace. Only reach for them when the decoupling is genuinely valuable.
+
+## Built-in Signals
+
+```python
+from django.db.models.signals import (
+    pre_save,    # before Model.save()
+    post_save,   # after Model.save()
+    pre_delete,  # before Model.delete()
+    post_delete, # after Model.delete()
+    m2m_changed, # ManyToManyField add/remove/clear/set
+)
+from django.db.models.signals import pre_migrate, post_migrate
+from django.core.signals import request_started, request_finished, got_request_exception
+from django.test.signals import setting_changed
+```
+
+`post_save` passes `created: bool` and `update_fields`. `m2m_changed` passes `action` (`"pre_add"`, `"post_add"`, `"pre_remove"`, `"post_remove"`, `"pre_clear"`, `"post_clear"`) and `pk_set`.
+
+## Receiver Registration
+
+### Decorator (preferred)
+
+```python
+# myapp/signals.py
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from orders.models import Order
+
+
+@receiver(post_save, sender=Order)
+def order_post_save(sender, instance: Order, created: bool, **kwargs) -> None:
+    if created:
+        notify_fulfillment.delay(order_id=instance.id)
+```
+
+Connect in `AppConfig.ready()` — never at module level or in `models.py`:
+
+```python
+# myapp/apps.py
+class MyAppConfig(AppConfig):
+    name = "myapp"
+
+    def ready(self) -> None:
+        import myapp.signals  # noqa: F401 — side effects only
+```
+
+```python
+# myapp/__init__.py
+default_app_config = "myapp.apps.MyAppConfig"
+```
+
+### `.connect()` (for conditional or programmatic wiring)
+
+```python
+post_save.connect(order_post_save, sender=Order, weak=False)
+```
+
+Pass `weak=False` when the receiver is a lambda or a bound method — Python's default weak reference will let it be garbage-collected otherwise.
+
+## Custom Signals
+
+```python
+# orders/signals.py
+from django.dispatch import Signal
+
+# Name signals as verb phrases describing the event
+order_placed = Signal()       # provides: order
+order_cancelled = Signal()    # provides: order, reason
+payment_failed = Signal()     # provides: order, error_code
+```
+
+Dispatch with keyword arguments only. Document what `kwargs` receivers can expect — there's no schema enforcement.
+
+```python
+# orders/services.py
+from orders.signals import order_placed
+
+class OrderService:
+    @staticmethod
+    @transaction.atomic
+    def order_create(*, ...) -> Order:
+        order = Order(...)
+        order.full_clean()
+        order.save(pre_save=False, post_save=False)
+        order_placed.send(sender=OrderService, order=order)
+        return order
+```
+
+Prefer `send_robust()` when you can't let a failing receiver abort the operation:
+
+```python
+results = order_placed.send_robust(sender=OrderService, order=order)
+for receiver, response in results:
+    if isinstance(response, Exception):
+        logger.exception("Signal receiver %s failed", receiver, exc_info=response)
+```
+
+`send()` propagates the first exception. `send_robust()` catches all exceptions and returns them in the results list.
+
+## Signal Ordering
+
+Receivers fire in the order they connect. There is no priority system. If ordering matters, either:
+
+1. Use a single receiver that explicitly sequences calls, or
+2. Refactor to a service that calls the handlers directly
+
+Relying on implicit receiver ordering is fragile.
+
+## Async Signals (Django 5.0+)
+
+Use `asend()` in async contexts. Sync receivers are automatically wrapped with `sync_to_async`; async receivers run concurrently via `asyncio.gather()`.
+
+```python
+from django.dispatch import Signal
+
+order_placed = Signal()
+
+async def notify_warehouse(sender, order, **kwargs) -> None:
+    await warehouse_api.post_order(order.id)
+
+order_placed.connect(notify_warehouse, weak=False)
+
+# Dispatch from async code
+await order_placed.asend(sender=OrderService, order=order)
+```
+
+Use `asend_robust()` to suppress receiver exceptions in async code, same as the sync equivalent.
+
+Mixing sync and async receivers on the same signal is fine. Django handles the adaptation automatically.
+
+## Transaction Timing
+
+`post_save` fires **inside** the current transaction. If you dispatch a Celery task from a `post_save` receiver, the task may run before the transaction commits and find no row.
+
+Use `transaction.on_commit()`:
+
+```python
+from django.db import transaction
+
+@receiver(post_save, sender=Order)
+def order_post_save(sender, instance: Order, created: bool, **kwargs) -> None:
+    if created:
+        transaction.on_commit(lambda: notify_fulfillment.delay(order_id=instance.id))
+```
+
+Or use `delay_on_commit()` if your task class supports it (see `celery-tasks` skill):
+
+```python
+@receiver(post_save, sender=Order)
+def order_post_save(sender, instance: Order, created: bool, **kwargs) -> None:
+    if created:
+        notify_fulfillment.delay_on_commit(order_id=instance.id)
+```
+
+## Common Pitfalls
+
+### Double-firing
+
+`bulk_create()` and `bulk_update()` do **not** call `.save()`, so `pre_save`/`post_save` signals are **not** sent. If you need signals for bulk operations, send them manually or use the save-hook service pattern (see `django-save-hooks`).
+
+`update()` on a QuerySet also skips signals.
+
+### Circular imports
+
+Receivers import models; models import signals; signals import receivers. Break the cycle:
+
+- Keep signal definitions in `signals.py`, receivers in the same file or a separate `receivers.py`
+- Import models inside the receiver function body if needed, not at module level
+- Import `signals.py` only in `AppConfig.ready()`, never at module top level
+
+```python
+# Bad: circular import risk
+# myapp/models.py
+from myapp.signals import order_placed  # signals.py imports models.py
+
+# Good: late import inside ready()
+class MyAppConfig(AppConfig):
+    def ready(self) -> None:
+        import myapp.signals  # noqa: F401
+```
+
+### Weak references drop receivers
+
+```python
+def make_handler():
+    def handler(sender, **kwargs):
+        ...
+    post_save.connect(handler, sender=Order)  # garbage-collected immediately
+    # handler goes out of scope here
+
+# Fix: pass weak=False, or use module-level functions
+post_save.connect(handler, sender=Order, weak=False)
+```
+
+### Mutations inside receivers
+
+Receivers should not call `.save()` on the instance they received — it re-fires the signal. Use `update_fields` to limit re-entry, or update via `QuerySet.update()`:
+
+```python
+@receiver(post_save, sender=Order)
+def set_slug(sender, instance: Order, created: bool, **kwargs) -> None:
+    if created and not instance.slug:
+        # Wrong: Order.save() -> post_save -> set_slug -> Order.save() -> ...
+        # instance.slug = slugify(instance.name)
+        # instance.save()
+
+        # Correct: bypass .save() signal re-entry
+        Order.objects.filter(pk=instance.pk).update(slug=slugify(instance.name))
+```
+
+## Testing Signals
+
+Use `mock.patch` or Django's `disconnect()` to isolate signal behavior.
+
+### Assert a signal was sent
+
+```python
+from unittest.mock import MagicMock
+from django.test import TestCase
+from orders.signals import order_placed
+
+
+def test_order_create_sends_signal(order_factory):
+    handler = MagicMock()
+    order_placed.connect(handler, weak=False)
+    try:
+        order = OrderService.order_create(...)
+        handler.assert_called_once()
+        _, kwargs = handler.call_args
+        assert kwargs["order"] == order
+    finally:
+        order_placed.disconnect(handler)
+```
+
+### Test receiver logic directly
+
+Prefer testing the receiver function directly rather than firing signals through the ORM:
+
+```python
+from orders.signals import order_post_save
+
+
+def test_order_post_save_queues_fulfillment(order, mock_task):
+    order_post_save(sender=Order, instance=order, created=True)
+    mock_task.delay_on_commit.assert_called_once_with(order_id=order.id)
+```
+
+### Disconnect in tests to prevent side effects
+
+```python
+import pytest
+from django.db.models.signals import post_save
+from orders.signals import order_post_save
+
+
+@pytest.fixture(autouse=True)
+def disable_order_signals():
+    post_save.disconnect(order_post_save, sender=Order)
+    yield
+    post_save.connect(order_post_save, sender=Order)
+```
+
+Or use `django.test.utils.isolate_apps` / `mock.patch.object(signal, "send")` for broader suppression.
+
+## Anti-Patterns to Avoid
+
+- Using signals for logic within the same app — use save hooks or services instead
+- Importing signal receivers at module level (causes circular imports)
+- Relying on receiver firing order for correctness
+- Calling `.save()` on the received instance from a `post_save` receiver
+- Dispatching Celery tasks directly from signals without `on_commit`
+- Forgetting `weak=False` for lambda or bound-method receivers
+- Using `send()` when receiver failures should be tolerated — use `send_robust()`
+
+---

--- a/skills/error-handling/SKILL.md
+++ b/skills/error-handling/SKILL.md
@@ -1,0 +1,358 @@
+---
+name: error-handling
+description: Exception hierarchy design, catch/propagate decisions, and error response patterns. Use when writing error handling in Django views, APIs, or service layer code.
+user-invocable: false
+---
+
+# Error Handling Guidelines
+
+## Exception Hierarchy
+
+Define a base exception per app or domain. All domain-specific exceptions inherit from it. This lets callers catch broadly (the base) or narrowly (a specific subclass).
+
+```python
+# accounts/exceptions.py
+class AccountsError(Exception):
+    """Base for all accounts-domain errors."""
+
+class UserNotFoundError(AccountsError):
+    pass
+
+class InsufficientPermissionsError(AccountsError):
+    pass
+
+class DuplicateEmailError(AccountsError):
+    def __init__(self, email: str) -> None:
+        self.email = email
+        super().__init__(f"Email already registered: {email}")
+```
+
+```python
+# orders/exceptions.py
+class OrdersError(Exception):
+    """Base for all orders-domain errors."""
+
+class OrderNotFoundError(OrdersError):
+    pass
+
+class OrderAlreadyCancelledError(OrdersError):
+    pass
+
+class PaymentFailedError(OrdersError):
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(f"Payment failed: {reason}")
+```
+
+Rules:
+- One `exceptions.py` per app (or per domain package if the app is large)
+- Base exception name matches the app: `<AppName>Error`
+- Attach relevant data as attributes, not only in the message string
+- Never inherit from `ValueError`, `RuntimeError`, or other builtins — use your domain base
+
+## When to Catch vs Propagate
+
+**Catch** when you can handle the error meaningfully: recover, retry, translate to a user-facing message, or add context.
+
+**Propagate** (let it bubble) when the caller is better positioned to decide what to do.
+
+```python
+# Service: catch to translate low-level errors into domain errors
+@staticmethod
+def user_create(*, email: str, password: str) -> "User":
+    try:
+        user = User.objects.create_user(email=email, password=password)
+    except IntegrityError:
+        raise DuplicateEmailError(email=email)
+    return user
+
+# View: catch domain errors to produce HTTP responses
+def register_view(request):
+    ...
+    try:
+        user = AccountsService.user_create(email=email, password=password)
+    except DuplicateEmailError:
+        form.add_error("email", "This email is already registered.")
+        return render(request, "accounts/register.html", {"form": form})
+    return redirect("dashboard")
+```
+
+```python
+# Service: propagate — let the caller handle it
+@staticmethod
+def order_cancel(*, order: "Order", user: "User") -> None:
+    if order.status == "cancelled":
+        raise OrderAlreadyCancelledError
+    order.status = "cancelled"
+    order.full_clean()
+    order.save()
+```
+
+Rules:
+- Services translate low-level exceptions (DB errors, HTTP errors) into domain exceptions
+- Services propagate domain exceptions upward — they do not produce HTTP responses
+- Views and API endpoints are the correct place to catch domain exceptions and return responses
+- Never swallow an exception silently (no bare `except: pass`)
+
+## Django's Built-in Exceptions
+
+These are handled by Django's middleware and produce standard HTTP responses automatically. Raise them in views or service code when appropriate.
+
+```python
+from django.http import Http404
+from django.core.exceptions import PermissionDenied, ValidationError
+
+# Http404 → 404 response (also triggers 404.html template)
+def article_detail(request, pk):
+    article = get_object_or_404(Article, pk=pk)
+    # or:
+    try:
+        article = Article.objects.get(pk=pk)
+    except Article.DoesNotExist:
+        raise Http404
+
+# PermissionDenied → 403 response
+def admin_view(request):
+    if not request.user.is_staff:
+        raise PermissionDenied
+
+# ValidationError — raised by full_clean(), caught in forms automatically
+# In a service context, let it propagate to the view/form layer
+```
+
+Do not catch `Http404` or `PermissionDenied` inside services. Raise them from views only, or raise your own domain exceptions from services and translate in the view.
+
+## Error Responses in Views
+
+Django views: use form errors for user-visible validation feedback.
+
+```python
+def order_create_view(request):
+    if request.method == "POST":
+        form = OrderForm(request.POST)
+        if form.is_valid():
+            try:
+                order = OrdersService.order_create(
+                    user=request.user,
+                    product_id=form.cleaned_data["product_id"],
+                    quantity=form.cleaned_data["quantity"],
+                )
+            except PaymentFailedError as exc:
+                form.add_error(None, f"Payment declined: {exc.reason}")
+            except OrdersError:
+                form.add_error(None, "Could not place order. Please try again.")
+            else:
+                return redirect("order_detail", pk=order.pk)
+    else:
+        form = OrderForm()
+    return render(request, "orders/create.html", {"form": form})
+```
+
+## Error Responses in APIs (Django Ninja)
+
+Use `HttpError` for explicit status codes. Let Pydantic validation errors surface automatically (Ninja handles them as 422).
+
+```python
+from ninja.errors import HttpError
+from django.core.exceptions import ValidationError
+
+@router.post("/orders/", response=OrderResponse)
+def create_order(request, data: CreateOrderRequest) -> OrderResponse:
+    try:
+        order = OrdersService.order_create(
+            user=request.user,
+            product_id=data.product_id,
+            quantity=data.quantity,
+        )
+    except PaymentFailedError as exc:
+        raise HttpError(402, exc.reason)
+    except OrderNotFoundError:
+        raise HttpError(404, "Order not found")
+    except OrdersError as exc:
+        raise HttpError(400, str(exc))
+    return OrderResponse.from_orm(order)
+```
+
+For consistent error shapes across the API, configure a global exception handler:
+
+```python
+# app/api.py
+from ninja import NinjaAPI
+from orders.exceptions import OrdersError
+
+api = NinjaAPI()
+
+@api.exception_handler(OrdersError)
+def orders_error_handler(request, exc):
+    return api.create_response(request, {"detail": str(exc)}, status=400)
+```
+
+## Structured Error Reporting (Logging Integration)
+
+See the `logging` skill for log levels and formatting rules. In error handling:
+
+- Log at `ERROR` for unexpected failures; do not log expected domain errors (e.g., duplicate email) at error level
+- Use `logger.exception()` to capture the traceback automatically
+- Always re-raise or raise a new exception after logging — do not log and swallow
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+
+@staticmethod
+def payment_charge(*, order: "Order", amount: Decimal) -> None:
+    try:
+        payment_gateway.charge(order.id, amount)
+    except payment_gateway.NetworkError as exc:
+        logger.exception("Payment gateway network error for order %s", order.id)
+        raise PaymentFailedError(reason="Gateway unreachable") from exc
+    except payment_gateway.DeclinedError as exc:
+        # Expected — no error log, just a domain exception
+        raise PaymentFailedError(reason=str(exc)) from exc
+```
+
+Use `raise ... from exc` to chain exceptions so the original traceback is preserved.
+
+## Service Layer Error Patterns
+
+See the `django-services` skill for service structure. Error handling within services:
+
+```python
+@staticmethod
+@transaction.atomic
+def order_fulfil(*, order: "Order") -> None:
+    if order.status != "paid":
+        raise OrdersError(f"Cannot fulfil order in status '{order.status}'")
+
+    try:
+        InventoryService.reserve_stock(order=order)
+    except InventoryError as exc:
+        # Translate cross-domain error if needed, or let it propagate
+        raise OrdersError("Stock reservation failed") from exc
+
+    order.status = "fulfilling"
+    order.full_clean()
+    order.save()
+```
+
+Rules for services:
+- Validate preconditions at the top of the method; raise immediately if not met
+- Catch foreign-domain exceptions and re-raise as your domain's exception if the caller shouldn't need to know about the foreign domain
+- Let `ValidationError` from `full_clean()` propagate — the caller (view/form) handles it
+- Use `@transaction.atomic` — if an exception is raised mid-way, the transaction rolls back automatically
+
+## Retry-Safe Error Handling
+
+When a service operation may be retried (e.g., from a Celery task), it must be idempotent or use explicit guards.
+
+```python
+# orders/tasks.py
+@shared_task(
+    bind=True,
+    autoretry_for=(PaymentFailedError,),
+    retry_backoff=True,
+    max_retries=3,
+)
+def charge_order_task(self, order_id: int) -> None:
+    order = Order.objects.get(pk=order_id)
+    if order.status == "paid":
+        return  # Already done — safe to retry
+    OrdersService.payment_charge(order=order, amount=order.total)
+```
+
+For exceptions that should NOT be retried (e.g., user input errors, permanent failures), do not include them in `autoretry_for`:
+
+```python
+# Non-retryable: raise immediately, do not retry
+class PermanentPaymentError(OrdersError):
+    """Card permanently declined, fraud flagged, etc."""
+
+@shared_task(
+    autoretry_for=(PaymentFailedError,),  # Only transient errors
+    max_retries=3,
+)
+def charge_order_task(order_id: int) -> None:
+    ...
+    # PermanentPaymentError bubbles out and is NOT retried
+```
+
+See the `celery-tasks` skill for task error patterns.
+
+## Anti-Patterns
+
+**Bare except** — catches `SystemExit`, `KeyboardInterrupt`, and hides bugs:
+```python
+# Wrong
+try:
+    process()
+except:
+    pass
+
+# Correct: catch what you expect, at minimum Exception
+try:
+    process()
+except SpecificError:
+    handle()
+```
+
+**Swallowing errors** — silent failures are the hardest bugs to diagnose:
+```python
+# Wrong
+try:
+    send_email(user)
+except Exception:
+    pass  # "It's not critical"
+
+# Correct: log it, even if you don't re-raise
+try:
+    send_email(user)
+except Exception:
+    logger.exception("Failed to send email to user %s", user.id)
+```
+
+**Exception-driven flow control** — exceptions are for errors, not branching:
+```python
+# Wrong: using exceptions as if/else
+try:
+    return cache.get(key)
+except KeyError:
+    return compute_value()
+
+# Correct: use the API designed for it
+value = cache.get(key, default=None)
+if value is None:
+    value = compute_value()
+```
+
+**Catching too broadly** — masks unexpected errors:
+```python
+# Wrong: catches everything including programming errors
+try:
+    result = OrdersService.order_create(...)
+except Exception:
+    return HttpResponse("Something went wrong", status=400)
+
+# Correct: catch only what you expect
+try:
+    result = OrdersService.order_create(...)
+except OrdersError as exc:
+    return HttpResponse(str(exc), status=400)
+```
+
+**Losing the original exception** — always use `raise ... from exc` when re-raising:
+```python
+# Wrong: original traceback lost
+try:
+    db_call()
+except IntegrityError:
+    raise DuplicateEmailError(email)
+
+# Correct: chain the exception
+try:
+    db_call()
+except IntegrityError as exc:
+    raise DuplicateEmailError(email) from exc
+```
+
+---


### PR DESCRIPTION
## Summary

- Adds `skills/django-admin/SKILL.md` covering ModelAdmin patterns, inlines, custom actions, custom views and URLs, template overriding, permissions, performance, and AdminSite customization

## Test plan

- [ ] Verify skill loads via `/reload-plugins` in Claude Code
- [ ] Confirm skill appears as `donna:django-admin` in skill list

Closes #15